### PR TITLE
fix: drop retired extension-refresh feature flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,3 @@ RUN apk update && \
     /var/tmp/*
 
 COPY --chmod=755 ./docker_entrypoint.sh /usr/local/bin/docker_entrypoint.sh
-
-ENV EXPERIMENTAL_CLIENT_FEATURE_FLAGS=extension-refresh

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "id": "vaultwarden",
   "title": "Vaultwarden",
-  "version": "1.36.0",
-  "release-notes": "* Updated to the latest upstream code containing security fixes:\n    Release notes: [v1.36.0](https://github.com/dani-garcia/vaultwarden/releases/tag/1.36.0)",
+  "version": "1.36.0.1",
+  "release-notes": "* Removed the retired `extension-refresh` experimental client feature flag. Vaultwarden 1.36.0 dropped this flag from its supported list, so its presence (injected by the package as an environment variable) made every admin-panel configuration save fail with an \"Unrecognized experimental client feature flags\" error. Updating clears the flag.",
   "license": "AGPLv3",
   "wrapper-repo": "https://github.com/Start9Labs/vaultwarden-startos",
   "upstream-repo": "https://github.com/dani-garcia/vaultwarden",


### PR DESCRIPTION
Vaultwarden 1.36.0 removed `extension-refresh` from its supported experimental-client-feature-flag allowlist. The package bakes `ENV EXPERIMENTAL_CLIENT_FEATURE_FLAGS=extension-refresh` into the Docker image, so on 1.36.0 every admin-panel config save fails validation (`Unrecognized experimental client feature flags`). The flag is an image env var — not stored in `config.json` or on the data volume — so users have no in-StartOS way to clear it.

Removes the `ENV` line and bumps to `1.36.0.1`. Because the flag lived only in the image environment, the rebuilt image clears it on update with no data migration.

Fixes #69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
