### PR TITLE
fix: surface start-sdk 2.0 migration notes on current (1.36.0:5)

### DIFF
--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,13 +1,13 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '1.36.0:4',
+  version: '1.36.0:5',
   releaseNotes: {
-    en_US: 'Internal updates',
-    es_ES: 'Actualizaciones internas',
-    de_DE: 'Interne Aktualisierungen',
-    pl_PL: 'Aktualizacje wewnętrzne',
-    fr_FR: 'Mises à jour internes',
+    en_US: `This release migrates the package to start-sdk 2.0 (requires StartOS 0.4.0-beta.10 or later). Vaultwarden itself is unchanged (1.36.0).`,
+    es_ES: `Esta versión migra el paquete a start-sdk 2.0 (requiere StartOS 0.4.0-beta.10 o posterior). Vaultwarden no cambia (1.36.0).`,
+    de_DE: `Diese Version stellt das Paket auf start-sdk 2.0 um (erfordert StartOS 0.4.0-beta.10 oder neuer). Vaultwarden selbst ist unverändert (1.36.0).`,
+    pl_PL: `Ta wersja przenosi pakiet na start-sdk 2.0 (wymaga StartOS 0.4.0-beta.10 lub nowszego). Vaultwarden pozostaje bez zmian (1.36.0).`,
+    fr_FR: `Cette version fait passer le paquet à start-sdk 2.0 (nécessite StartOS 0.4.0-beta.10 ou une version ultérieure). Vaultwarden lui-même est inchangé (1.36.0).`,
   },
   migrations: {},
 })


### PR DESCRIPTION
## Problem

`current` shipped the placeholder `"Internal updates"` note. The manifest and StartOS upgrade UI surface only `versions.current.releaseNotes` (start-sdk `setupManifest.ts:71`), so that placeholder is what users saw. This release was the start-sdk 2.0 migration with no upstream app change.

## Fix

Replaces the placeholder with a proper description of the release (the start-sdk 2.0 migration) and bumps the revision to `1.36.0:5`. Migrations and `other[]` are left untouched.

## Test plan

- [ ] CI build is green.
- [ ] Install/upgrade to `1.36.0:5`; confirm the StartOS upgrade screen shows the real Vaultwarden release notes, not "Internal updates".