### PR TITLE
fix: bump Vaultwarden to 1.37.0 for Bitwarden 2026.7.0 client compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "vaultwarden-startos",
       "dependencies": {
-        "@start9labs/start-sdk": "2.0.7"
+        "@start9labs/start-sdk": "2.0.9"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -61,9 +61,9 @@
       "license": "MIT"
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-2.0.7.tgz",
-      "integrity": "sha512-lJuZto0vfD/2fPubzwavuStAdlnQQo8AmYFvBBhENY4WbXAXJ64b5zuXwrkmJ8wZObUngno5LYZWWr7yOlYLxQ==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-2.0.9.tgz",
+      "integrity": "sha512-HuSYrS10Bb+f6OyAMlCzd5Qyr+rIauiI0dF8MVh5Ny+eU0gF8/DeFAXlHFgL+9wkSv4UAP5q5yOzlBpXzsNbWQ==",
       "bundleDependencies": [
         "@start9labs/start-core",
         "eslint",
@@ -332,163 +332,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core": {
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@iarna/toml": "^3.0.0",
-        "@noble/curves": "^1.9.7",
-        "@noble/hashes": "^1.8.0",
-        "deep-equality-data-structures": "^2.0.0",
-        "isomorphic-fetch": "^3.0.0",
-        "mime": "^4.1.0",
-        "yaml": "^2.8.3",
-        "zod": "4.4.3",
-        "zod-deep-partial": "^1.4.4"
-      }
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/@iarna/toml": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/@noble/curves": {
-      "version": "1.9.7",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/deep-equality-data-structures": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "object-hash": "^3.0.0"
-      }
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/isomorphic-fetch": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
-      }
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/mime": {
-      "version": "4.1.0",
-      "funding": [
-        "https://github.com/sponsors/broofa"
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "mime": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/object-hash": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/tr46": {
-      "version": "0.0.3",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "inBundle": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/whatwg-fetch": {
-      "version": "3.6.20",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/yaml": {
-      "version": "2.9.0",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/zod": {
-      "version": "4.4.3",
-      "inBundle": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@start9labs/start-sdk/node_modules/@start9labs/start-core/node_modules/zod-deep-partial": {
-      "version": "1.4.4",
-      "inBundle": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "zod": "^4.1.13"
       }
     },
     "node_modules/@start9labs/start-sdk/node_modules/@types/estree": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "2.0.7"
+    "@start9labs/start-sdk": "2.0.9"
   },
   "devDependencies": {
     "@types/node": "^22.19.3",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -14,7 +14,7 @@ export const manifest = setupManifest({
   images: {
     vaultwarden: {
       source: {
-        dockerTag: 'vaultwarden/server:1.36.0-alpine',
+        dockerTag: 'vaultwarden/server:1.37.0-alpine',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,13 +1,43 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '1.36.0:6',
+  version: '1.37.0:1',
   releaseNotes: {
-    en_US: `This release migrates the package to start-sdk 2.0 (requires StartOS 0.4.0-beta.10 or later). Vaultwarden itself is unchanged (1.36.0).`,
-    es_ES: `Esta versión migra el paquete a start-sdk 2.0 (requiere StartOS 0.4.0-beta.10 o posterior). Vaultwarden no cambia (1.36.0).`,
-    de_DE: `Diese Version stellt das Paket auf start-sdk 2.0 um (erfordert StartOS 0.4.0-beta.10 oder neuer). Vaultwarden selbst ist unverändert (1.36.0).`,
-    pl_PL: `Ta wersja przenosi pakiet na start-sdk 2.0 (wymaga StartOS 0.4.0-beta.10 lub nowszego). Vaultwarden pozostaje bez zmian (1.36.0).`,
-    fr_FR: `Cette version fait passer le paquet à start-sdk 2.0 (nécessite StartOS 0.4.0-beta.10 ou une version ultérieure). Vaultwarden lui-même est inchangé (1.36.0).`,
+    en_US: `**Required update for Bitwarden clients 2026.7.0 and later.** The 2026.7.0 Bitwarden clients (browser extension, desktop, and mobile) changed what they expect from the server API. Against Vaultwarden 1.36.0 they log in successfully but the vault never loads — the item list sits on grey placeholders indefinitely. Vaultwarden 1.37.0 restores compatibility.
+
+**After updating, force a sync in each client**, or log out and back in. A client that last synced against 1.36.0 keeps showing an empty vault until it re-syncs.
+
+**Security fixes.** 1.37.0 resolves eight upstream advisories, all rated Medium: SSRF via the icon endpoint, cross-organization cipher access, cross-organization secret sharing, organization policy bypass on directory import, organization import authorization, organization data enumeration via the Manager role, Send access-count bypass, and unauthenticated WebSocket flooding. Updating promptly is recommended.
+
+Upstream release notes: https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.0`,
+    es_ES: `**Actualización obligatoria para los clientes de Bitwarden 2026.7.0 y posteriores.** Los clientes de Bitwarden 2026.7.0 (extensión de navegador, escritorio y móvil) cambiaron lo que esperan de la API del servidor. Con Vaultwarden 1.36.0 inician sesión correctamente pero la caja fuerte nunca carga: la lista de elementos se queda indefinidamente en marcadores de posición grises. Vaultwarden 1.37.0 restaura la compatibilidad.
+
+**Después de actualizar, fuerza una sincronización en cada cliente**, o cierra la sesión y vuelve a iniciarla. Un cliente cuya última sincronización fue contra 1.36.0 seguirá mostrando una caja fuerte vacía hasta que vuelva a sincronizar.
+
+**Correcciones de seguridad.** 1.37.0 resuelve ocho avisos de seguridad upstream, todos de gravedad Media: SSRF mediante el endpoint de iconos, acceso a credenciales entre organizaciones, uso compartido de secretos entre organizaciones, elusión de políticas de organización en la importación de directorios, autorización en la importación de organizaciones, enumeración de datos de la organización mediante el rol Manager, elusión del límite de accesos en Send y saturación de WebSocket sin autenticar. Se recomienda actualizar cuanto antes.
+
+Notas de la versión upstream: https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.0`,
+    de_DE: `**Erforderliches Update für Bitwarden-Clients ab 2026.7.0.** Die Bitwarden-Clients der Version 2026.7.0 (Browser-Erweiterung, Desktop und Mobil) haben ihre Erwartungen an die Server-API geändert. Mit Vaultwarden 1.36.0 melden sie sich erfolgreich an, der Tresor lädt jedoch nie – die Eintragsliste bleibt dauerhaft bei grauen Platzhaltern. Vaultwarden 1.37.0 stellt die Kompatibilität wieder her.
+
+**Erzwinge nach dem Update in jedem Client eine Synchronisierung**, oder melde dich ab und wieder an. Ein Client, der zuletzt mit 1.36.0 synchronisiert hat, zeigt weiterhin einen leeren Tresor, bis er neu synchronisiert.
+
+**Sicherheitskorrekturen.** 1.37.0 behebt acht Upstream-Advisories, alle mit Schweregrad Mittel: SSRF über den Icon-Endpunkt, organisationsübergreifender Zugriff auf Einträge, organisationsübergreifende Weitergabe von Secrets, Umgehung von Organisationsrichtlinien beim Verzeichnisimport, Autorisierung beim Organisationsimport, Enumeration von Organisationsdaten über die Manager-Rolle, Umgehung des Zugriffszählers bei Send und unauthentifiziertes WebSocket-Flooding. Ein zeitnahes Update wird empfohlen.
+
+Upstream-Release-Notes: https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.0`,
+    pl_PL: `**Wymagana aktualizacja dla klientów Bitwarden 2026.7.0 i nowszych.** Klienci Bitwarden w wersji 2026.7.0 (rozszerzenie przeglądarki, aplikacja desktopowa i mobilna) zmienili swoje oczekiwania wobec API serwera. Na Vaultwarden 1.36.0 logowanie się udaje, ale sejf nigdy się nie ładuje — lista wpisów pozostaje bezterminowo na szarych symbolach zastępczych. Vaultwarden 1.37.0 przywraca zgodność.
+
+**Po aktualizacji wymuś synchronizację w każdym kliencie** lub wyloguj się i zaloguj ponownie. Klient, który ostatnio synchronizował się z wersją 1.36.0, będzie pokazywał pusty sejf do momentu ponownej synchronizacji.
+
+**Poprawki bezpieczeństwa.** 1.37.0 usuwa osiem zgłoszeń bezpieczeństwa upstream, wszystkie o istotności Średniej: SSRF przez endpoint ikon, dostęp do wpisów między organizacjami, udostępnianie sekretów między organizacjami, obejście zasad organizacji przy imporcie katalogu, autoryzacja przy imporcie organizacji, enumeracja danych organizacji przez rolę Manager, obejście licznika dostępu w Send oraz nieuwierzytelnione zalewanie WebSocket. Zalecana jest niezwłoczna aktualizacja.
+
+Informacje o wydaniu upstream: https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.0`,
+    fr_FR: `**Mise à jour obligatoire pour les clients Bitwarden 2026.7.0 et ultérieurs.** Les clients Bitwarden 2026.7.0 (extension de navigateur, ordinateur et mobile) ont modifié ce qu'ils attendent de l'API du serveur. Avec Vaultwarden 1.36.0, la connexion réussit mais le coffre ne se charge jamais : la liste des éléments reste indéfiniment sur des espaces réservés gris. Vaultwarden 1.37.0 rétablit la compatibilité.
+
+**Après la mise à jour, forcez une synchronisation dans chaque client**, ou déconnectez-vous puis reconnectez-vous. Un client dont la dernière synchronisation s'est faite avec 1.36.0 continuera d'afficher un coffre vide jusqu'à ce qu'il se resynchronise.
+
+**Corrections de sécurité.** 1.37.0 corrige huit avis de sécurité en amont, tous de gravité Moyenne : SSRF via le point de terminaison des icônes, accès aux éléments entre organisations, partage de secrets entre organisations, contournement des politiques d'organisation lors de l'import d'annuaire, autorisation lors de l'import d'organisation, énumération des données d'organisation via le rôle Manager, contournement du compteur d'accès des Send et saturation WebSocket non authentifiée. Une mise à jour rapide est recommandée.
+
+Notes de version en amont : https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.0`,
   },
   migrations: {},
 })


### PR DESCRIPTION
## Summary

Bumps Vaultwarden **1.36.0 → 1.37.0** (`1.36.0:6` → `1.37.0:1`).

Bitwarden shipped client **2026.7.0** today, changing what its clients expect from the server API. Against Vaultwarden 1.36.0 clients authenticate and sync successfully — every request returns `200 OK` — but the vault never renders, leaving the item list on loading skeletons indefinitely. The Bitwarden WASM SDK throws while deserializing ciphers:

```
invalid type: JsValue(Object({"fields":[],"name":"2....","password":"2....", ...})), expected a string
    je bitwarden_wasm_internal_bg.js:6830
```

and the unhandled Angular error takes the vault list down with it.

Reproduced by three users here, and confirmed upstream in dani-garcia/vaultwarden#7476, #7474, #7471, #7469, and #7462. Vaultwarden's 1.37.0 release notes lead with:

> This update is required for support with clients with version 2026.7.0+, please update before reporting any issues with them.

The break affects every client family — browser extension, desktop, and mobile — and is independent of how the server is reached: LAN `.local`, LAN IP, and clearnet all fail identically. Only clients whose stored state predates the 2026.7.0 update keep working, until they re-sync.

## Security

1.37.0 also resolves **eight upstream advisories**, all rated Medium:

| Advisory | CVSS |
| --- | --- |
| SSRF via the icon endpoint | 5.8 / 6.3 |
| Cross-Organization Cipher Access | 5.9 |
| Organization Policy Bypass on Directory Import | 5.5 |
| Send Access-Count Bypass | 5.3 |
| Unauthenticated WebSocket Flooding DDOS | 5.3 |
| Cross-Organization Secret Sharing | 4.3 |
| Organization Import Authorization | 4.3 |
| Organization Data Enumeration via the Manager role | 4.3 |

Everyone on the current package is on 1.36.0 and exposed to all of them, so this is worth shipping promptly on security grounds alone, independent of the client break.

## Changes

- `startos/manifest/index.ts` — `vaultwarden/server:1.36.0-alpine` → `vaultwarden/server:1.37.0-alpine`
- `startos/versions/current.ts` — `1.36.0:6` → `1.37.0:1`, with release notes in all five locales
- `package.json` / `package-lock.json` — `@start9labs/start-sdk` `2.0.7` → `2.0.9`

No package migration is needed: Vaultwarden runs its own database migrations on start. `startos/versions/index.ts` is unchanged — `1.36.0:3` remains the only entry in `other`, as it is the only version carrying a migration.

The SDK bump is inert for this package. 2.0.8 adds `sdk.host.getBridgeAddress` and 2.0.9 fixes its return type when `fallbackPort` is given; both are confined to dependency address resolution, and Vaultwarden declares no dependencies. The lockfile shrinks because 2.0.9 dedupes a nested `@start9labs/start-core` tree that 2.0.7 pinned separately — no other resolved package changes. The release notes deliberately don't mention it, since there is no user-visible effect to announce on a security release.

## Test plan

1. Install the built `.s9pk` on StartOS 0.4.0-beta.10 or later, **or** update an existing install from `1.36.0:6`.
2. Confirm the service starts, reports healthy, and shows version `1.37.0:1`.
3. Open the **Web Vault** interface, log in to an existing account, and confirm existing items are present and decrypt correctly.
4. Open the **Admin Portal** at `/admin`, sign in with the admin token, and confirm the diagnostics page reports Vaultwarden `1.37.0`.
5. **Client compatibility** — using a Bitwarden browser extension on **2026.7.0 or later**:
   - Point it at the server's LAN `.local` URL and log in, then **force a sync** (or log out and back in).
   - Confirm vault items render instead of sitting on grey loading skeletons.
   - Repeat against the clearnet domain if one is configured.
   - Optionally repeat with a desktop or mobile client on 2026.7.0+.
6. Confirm the actions still behave: **Disable / Enable Signups**, **Update Admin Token**, **Set Primary Domain**, **Configure SMTP**.
7. **Upgrade path** — confirm a server updating from `1.36.0:6` keeps its users, vault items, and `config.json` settings (admin token, SMTP config, domain).

Note for testers: after the server upgrade, any client that last synced against 1.36.0 will keep showing an empty vault until it re-syncs. That is expected, and the release notes tell users to force a sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
