### PR TITLE
fix: read the client IP from X-Forwarded-For

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This package runs **2 containers**:
 
 | Volume | Mount Point | Contents |
 |--------|-------------|---------|
-| `main` | `/data` | Encrypted vault database (SQLite), config, attachments, `store.json` |
+| `main` | `/data` | Encrypted vault database (SQLite), `config.json`, `systemSmtp.json`, attachments |
 
 **Critical:** This volume contains all your passwords and sensitive data. Ensure backups are secure and tested.
 
@@ -56,7 +56,7 @@ This package runs **2 containers**:
 
 On first install:
 
-1. `config.json` and `store.json` are seeded with defaults
+1. `config.json` and `systemSmtp.json` are seeded with defaults
 2. Auto-selects a `.local` domain as primary if not configured
 3. A **critical task** is created prompting the user to run the **Create Admin Token** action
 4. On update, an **important task** is created for the **Toggle Signups** action to confirm signup state
@@ -71,6 +71,29 @@ No upstream setup wizard — admin token and primary domain are configured via S
 | Signups enabled/disabled | User settings within the web vault |
 | Primary domain (for links and invites) | |
 | SMTP (disabled / system / custom) | |
+
+### Client IP header
+
+`config.json` pins `ip_header` to `X-Forwarded-For`.
+
+Vaultwarden defaults this setting to `X-Real-IP`, which StartOS never sends. The OS
+reverse proxy removes the client-supplied `X-Forwarded-For`, `X-Forwarded-Proto`, and
+`X-Forwarded-User` headers — exactly those three, not the whole `X-Forwarded-*` family —
+then sets `X-Forwarded-For` itself, a single address rather than a list, for any binding
+declared with `protocol: 'http'`. Left at the upstream default, Vaultwarden falls back to
+the socket peer, so every request appears to come from the container gateway: per-client
+rate limiting collapses into one shared bucket and new-device-login notifications become
+meaningless.
+
+Any other `X-Forwarded-*` header reaches the service exactly as the client sent it, so
+don't treat the rest of the family as sanitized.
+
+Vaultwarden 1.37.0 additionally gates the header on `ip_header_trusted_proxies`, which
+defaults to `local` and trusts any non-global source address. The gateway qualifies, so
+no further setting is needed.
+
+The field is defaulted rather than written explicitly, so a user who changes it in the
+admin portal keeps their value.
 
 ## Network Access and Interfaces
 
@@ -167,7 +190,7 @@ None.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for build instructions and development workflow.
+See [AGENTS.md](AGENTS.md) for build instructions and development workflow.
 
 ---
 

--- a/startos/fileModels/config.json.ts
+++ b/startos/fileModels/config.json.ts
@@ -3,6 +3,7 @@ import { sdk } from '../sdk'
 
 const shape = z.object({
   domain: z.string().optional().catch(undefined),
+  ip_header: z.string().catch('X-Forwarded-For'),
   admin_token: z.string().optional().catch(undefined),
   signups_allowed: z.boolean().catch(false),
   smtp_host: z.string().optional().catch(undefined),


### PR DESCRIPTION
## Summary

Vaultwarden logged every request as coming from `10.0.3.1` — the StartOS container gateway — instead of the real client:

```
[vaultwarden::api::identity][INFO] User Matt Hill logged in successfully. IP: 10.0.3.1
```

Vaultwarden defaults `IP_HEADER` to `X-Real-IP`, and **StartOS never sets that header.** The OS reverse proxy removes the client-supplied `X-Forwarded-For`, `X-Forwarded-Proto`, and `X-Forwarded-User` headers, then inserts its own `X-Forwarded-For` (`shared-libs/crates/start-core/src/net/http.rs`, `apply_request_policy`). That path is active for this package because `knownProtocols.http` carries `addXForwardedHeaders: true` and the UI port binds with `protocol: 'http'`. Looking for a header that isn't there, Vaultwarden falls back to the socket peer — the gateway.

Two details worth recording, both verified against the source rather than the doc comment above that function:

- The proxy inserts a **single** address rather than appending to a list, so there's no comma-list precedence ambiguity to reason about.
- It removes **exactly those three headers** — there is no wildcard or prefix strip anywhere in `net/`. Other `X-Forwarded-*` headers, `X-Forwarded-Host` included, reach the service as the client sent them and must not be treated as sanitized.

## Why it matters

A single apparent client IP means:

- **Login rate limiting collapses into one shared bucket** across every user on the server. `LOGIN_RATELIMIT_*` and the unauthenticated limits added in 1.37.0 all key off client IP.
- **New-device-login notifications are meaningless** — every login looks like it came from the same address.

This got sharper with 1.37.0, whose `GHSA-96f7-78q5-j345` (unauthenticated WebSocket flooding DoS) mitigation leans on exactly those per-IP limits.

## Trusted proxies

1.37.0 added `ip_header_trusted_proxies` (#7472) and will **ignore** the IP header from an untrusted source. It defaults to `local`, which resolves to `!is_global(remote)`. `10.0.3.1` is RFC1918, so the gateway is trusted out of the box and no additional setting is required here.

## Changes

- `startos/fileModels/config.json.ts` — adds `ip_header: z.string().catch('X-Forwarded-For')`.
- `README.md` — documents the setting and why it's needed, under Configuration Management.

The field is **defaulted**, not written explicitly. `FileHelper.merge` re-validates the merged object through the zod shape, so `seedFiles`' existing `configJson.merge(effects, {})` fills it on update for installs that already exist — no migration needed — while a user who changes it in the admin portal keeps their value, since a present valid string parses without hitting `.catch()`.

**No version bump.** `1.37.0:1` has not moved past alpha, so this ships under the same version.

## Drive-by doc fixes

Both found while editing the README, neither related to the change:

- `README.md` linked to a `CONTRIBUTING.md` that doesn't exist in this repo — repointed at `AGENTS.md`.
- `README.md` listed `store.json` as seeded on install and as living on the `main` volume. It's a pre-SDK-2.0 leftover; the string appears nowhere else in the repo. Replaced with the file models that actually exist (`config.json`, `systemSmtp.json`).

## Test plan

1. Build and install the `.s9pk`, or update an existing install.
2. Confirm `config.json` on the `main` volume now contains `"ip_header": "X-Forwarded-For"`. On an existing install this should appear after the update without any action — that is the `merge` default path being exercised.
3. Start the service and log into the Web Vault **from another machine on the LAN**.
4. Check the service logs: the login line should now report that machine's LAN address rather than `10.0.3.1`.

   ```
   [vaultwarden::api::identity][INFO] User <name> logged in successfully. IP: 192.168.x.x
   ```

5. Open the **Admin Portal** → diagnostics and confirm **IP Header check** reports `true (X-Forwarded-For)`.
6. Repeat step 3 over a clearnet domain if one is configured, and confirm the reported address is the real remote client.
7. **User-override check** — set `ip_header` to something else in the admin portal, restart the service, and confirm the package does not overwrite it on the next init.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
