### PR TITLE
chore: bump vaultwarden to 1.37.1; 1.37.0:2 → 1.37.1:0

### DIFF
--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -14,7 +14,7 @@ export const manifest = setupManifest({
   images: {
     vaultwarden: {
       source: {
-        dockerTag: 'vaultwarden/server:1.37.0-alpine',
+        dockerTag: 'vaultwarden/server:1.37.1-alpine',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,43 +1,38 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '1.37.0:2',
+  version: '1.37.1:0',
   releaseNotes: {
-    en_US: `**Required update for Bitwarden clients 2026.7.0 and later.** The 2026.7.0 Bitwarden clients (browser extension, desktop, and mobile) changed what they expect from the server API. Against Vaultwarden 1.36.0 they log in successfully but the vault never loads — the item list sits on grey placeholders indefinitely. Vaultwarden 1.37.0 restores compatibility.
+    en_US: `Updated Vaultwarden to 1.37.1.
 
-**After updating, force a sync in each client**, or log out and back in. A client that last synced against 1.36.0 keeps showing an empty vault until it re-syncs.
+- Fixes organization invitations, which were broken in 1.37.0. If you applied a workaround for this locally, revert it now.
+- Rebuilds the Alpine image with a corrected OpenSSL build, fixing a startup crash on installs that connect to a MySQL/MariaDB database over TLS.
 
-**Security fixes.** 1.37.0 resolves eight upstream advisories, all rated Medium: SSRF via the icon endpoint, cross-organization cipher access, cross-organization secret sharing, organization policy bypass on directory import, organization import authorization, organization data enumeration via the Manager role, Send access-count bypass, and unauthenticated WebSocket flooding. Updating promptly is recommended.
+Upstream release notes: https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.1`,
+    es_ES: `Vaultwarden actualizado a 1.37.1.
 
-Upstream release notes: https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.0`,
-    es_ES: `**Actualización obligatoria para los clientes de Bitwarden 2026.7.0 y posteriores.** Los clientes de Bitwarden 2026.7.0 (extensión de navegador, escritorio y móvil) cambiaron lo que esperan de la API del servidor. Con Vaultwarden 1.36.0 inician sesión correctamente pero la caja fuerte nunca carga: la lista de elementos se queda indefinidamente en marcadores de posición grises. Vaultwarden 1.37.0 restaura la compatibilidad.
+- Corrige las invitaciones de organización, que no funcionaban en 1.37.0. Si aplicaste alguna solución alternativa localmente, deshazla ahora.
+- Reconstruye la imagen de Alpine con una compilación corregida de OpenSSL, lo que soluciona un fallo de arranque en instalaciones que se conectan a una base de datos MySQL/MariaDB mediante TLS.
 
-**Después de actualizar, fuerza una sincronización en cada cliente**, o cierra la sesión y vuelve a iniciarla. Un cliente cuya última sincronización fue contra 1.36.0 seguirá mostrando una caja fuerte vacía hasta que vuelva a sincronizar.
+Notas de la versión upstream: https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.1`,
+    de_DE: `Vaultwarden auf 1.37.1 aktualisiert.
 
-**Correcciones de seguridad.** 1.37.0 resuelve ocho avisos de seguridad upstream, todos de gravedad Media: SSRF mediante el endpoint de iconos, acceso a credenciales entre organizaciones, uso compartido de secretos entre organizaciones, elusión de políticas de organización en la importación de directorios, autorización en la importación de organizaciones, enumeración de datos de la organización mediante el rol Manager, elusión del límite de accesos en Send y saturación de WebSocket sin autenticar. Se recomienda actualizar cuanto antes.
+- Behebt Organisationseinladungen, die in 1.37.0 defekt waren. Falls du lokal einen Workaround dafür eingesetzt hast, mache ihn jetzt rückgängig.
+- Erstellt das Alpine-Image mit einem korrigierten OpenSSL-Build neu und behebt damit einen Startabsturz bei Installationen, die sich per TLS mit einer MySQL-/MariaDB-Datenbank verbinden.
 
-Notas de la versión upstream: https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.0`,
-    de_DE: `**Erforderliches Update für Bitwarden-Clients ab 2026.7.0.** Die Bitwarden-Clients der Version 2026.7.0 (Browser-Erweiterung, Desktop und Mobil) haben ihre Erwartungen an die Server-API geändert. Mit Vaultwarden 1.36.0 melden sie sich erfolgreich an, der Tresor lädt jedoch nie – die Eintragsliste bleibt dauerhaft bei grauen Platzhaltern. Vaultwarden 1.37.0 stellt die Kompatibilität wieder her.
+Upstream-Release-Notes: https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.1`,
+    pl_PL: `Zaktualizowano Vaultwarden do 1.37.1.
 
-**Erzwinge nach dem Update in jedem Client eine Synchronisierung**, oder melde dich ab und wieder an. Ein Client, der zuletzt mit 1.36.0 synchronisiert hat, zeigt weiterhin einen leeren Tresor, bis er neu synchronisiert.
+- Naprawia zaproszenia do organizacji, które nie działały w wersji 1.37.0. Jeśli zastosowano lokalnie obejście tego problemu, należy je teraz cofnąć.
+- Przebudowuje obraz Alpine z poprawioną kompilacją OpenSSL, co usuwa awarię uruchamiania w instalacjach łączących się z bazą danych MySQL/MariaDB przez TLS.
 
-**Sicherheitskorrekturen.** 1.37.0 behebt acht Upstream-Advisories, alle mit Schweregrad Mittel: SSRF über den Icon-Endpunkt, organisationsübergreifender Zugriff auf Einträge, organisationsübergreifende Weitergabe von Secrets, Umgehung von Organisationsrichtlinien beim Verzeichnisimport, Autorisierung beim Organisationsimport, Enumeration von Organisationsdaten über die Manager-Rolle, Umgehung des Zugriffszählers bei Send und unauthentifiziertes WebSocket-Flooding. Ein zeitnahes Update wird empfohlen.
+Informacje o wydaniu upstream: https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.1`,
+    fr_FR: `Vaultwarden mis à jour vers 1.37.1.
 
-Upstream-Release-Notes: https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.0`,
-    pl_PL: `**Wymagana aktualizacja dla klientów Bitwarden 2026.7.0 i nowszych.** Klienci Bitwarden w wersji 2026.7.0 (rozszerzenie przeglądarki, aplikacja desktopowa i mobilna) zmienili swoje oczekiwania wobec API serwera. Na Vaultwarden 1.36.0 logowanie się udaje, ale sejf nigdy się nie ładuje — lista wpisów pozostaje bezterminowo na szarych symbolach zastępczych. Vaultwarden 1.37.0 przywraca zgodność.
+- Corrige les invitations d'organisation, qui étaient cassées en 1.37.0. Si vous avez appliqué un contournement localement, annulez-le maintenant.
+- Reconstruit l'image Alpine avec une compilation OpenSSL corrigée, ce qui résout un plantage au démarrage sur les installations qui se connectent à une base de données MySQL/MariaDB via TLS.
 
-**Po aktualizacji wymuś synchronizację w każdym kliencie** lub wyloguj się i zaloguj ponownie. Klient, który ostatnio synchronizował się z wersją 1.36.0, będzie pokazywał pusty sejf do momentu ponownej synchronizacji.
-
-**Poprawki bezpieczeństwa.** 1.37.0 usuwa osiem zgłoszeń bezpieczeństwa upstream, wszystkie o istotności Średniej: SSRF przez endpoint ikon, dostęp do wpisów między organizacjami, udostępnianie sekretów między organizacjami, obejście zasad organizacji przy imporcie katalogu, autoryzacja przy imporcie organizacji, enumeracja danych organizacji przez rolę Manager, obejście licznika dostępu w Send oraz nieuwierzytelnione zalewanie WebSocket. Zalecana jest niezwłoczna aktualizacja.
-
-Informacje o wydaniu upstream: https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.0`,
-    fr_FR: `**Mise à jour obligatoire pour les clients Bitwarden 2026.7.0 et ultérieurs.** Les clients Bitwarden 2026.7.0 (extension de navigateur, ordinateur et mobile) ont modifié ce qu'ils attendent de l'API du serveur. Avec Vaultwarden 1.36.0, la connexion réussit mais le coffre ne se charge jamais : la liste des éléments reste indéfiniment sur des espaces réservés gris. Vaultwarden 1.37.0 rétablit la compatibilité.
-
-**Après la mise à jour, forcez une synchronisation dans chaque client**, ou déconnectez-vous puis reconnectez-vous. Un client dont la dernière synchronisation s'est faite avec 1.36.0 continuera d'afficher un coffre vide jusqu'à ce qu'il se resynchronise.
-
-**Corrections de sécurité.** 1.37.0 corrige huit avis de sécurité en amont, tous de gravité Moyenne : SSRF via le point de terminaison des icônes, accès aux éléments entre organisations, partage de secrets entre organisations, contournement des politiques d'organisation lors de l'import d'annuaire, autorisation lors de l'import d'organisation, énumération des données d'organisation via le rôle Manager, contournement du compteur d'accès des Send et saturation WebSocket non authentifiée. Une mise à jour rapide est recommandée.
-
-Notes de version en amont : https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.0`,
+Notes de version en amont : https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.1`,
   },
   migrations: {},
 })


### PR DESCRIPTION
## Summary

Bumps Vaultwarden `1.37.0` → `1.37.1` (`vaultwarden/server:1.37.1-alpine`) and the package version `1.37.0:2` → `1.37.1:0`.

`1.37.1-alpine` is published on Docker Hub (8 platform manifests, pushed 2026-07-29).

## Upstream changes

- **Organization invitations fixed.** 1.37.0 stopped sending `initOrganization` / `orgUserHasExistingUser` in the invite URL, breaking invites (dani-garcia/vaultwarden#7482). Upstream asks anyone who applied a local workaround to revert it.
- **Alpine images rebuilt** against newer `rust-musl` build images, resolving an OpenSSL compilation problem that segfaulted at startup when connecting to MySQL/MariaDB over TLS (dani-garcia/vaultwarden#7475). This package uses the default SQLite backend, so StartOS installs were not affected, but the image we ship is the rebuilt one.

Full changelog: https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.1

## Other

- `@start9labs/start-sdk` is already at the latest published version (2.0.9) — no bump, no lockfile change. No `*-startos` git dependencies to refresh.
- No migration needed; a patch release with no state or config changes.
- README/instructions reviewed — the only version reference (`Vaultwarden 1.37.0 additionally gates the header on ip_header_trusted_proxies`) describes when the behaviour was introduced and remains accurate.

## Test plan

- [x] `npm run check` green (typecheck only, per monitor-cycle policy)
- [x] `1.37.1-alpine` tag verified on Docker Hub
- [x] `1.37.1:0` confirmed free on the registry (latest published is `1.37.0:2`)
- [ ] `make` / install verification in review
