### PR TITLE
chore: bump Vaultwarden to 1.37.2; 1.37.1:0 → 1.37.2:0

### DIFF
--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -14,7 +14,7 @@ export const manifest = setupManifest({
   images: {
     vaultwarden: {
       source: {
-        dockerTag: 'vaultwarden/server:1.37.1-alpine',
+        dockerTag: 'vaultwarden/server:1.37.2-alpine',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,38 +1,48 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '1.37.1:0',
+  version: '1.37.2:0',
   releaseNotes: {
-    en_US: `Updated Vaultwarden to 1.37.1.
+    en_US: `Updated Vaultwarden to 1.37.2.
 
-- Fixes organization invitations, which were broken in 1.37.0. If you applied a workaround for this locally, revert it now.
-- Rebuilds the Alpine image with a corrected OpenSSL build, fixing a startup crash on installs that connect to a MySQL/MariaDB database over TLS.
+- Required for Bitwarden clients on version 2026.8.0 or newer. Update before reporting problems with a recent client.
+- Updates the web vault to 2026.7.0.
+- Fixes updating the collections an item belongs to, and the event log for a single user.
+- Records the user's email address in successful login log entries.
 
-Upstream release notes: https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.1`,
-    es_ES: `Vaultwarden actualizado a 1.37.1.
+Upstream release notes: https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.2`,
+    es_ES: `Vaultwarden actualizado a 1.37.2.
 
-- Corrige las invitaciones de organización, que no funcionaban en 1.37.0. Si aplicaste alguna solución alternativa localmente, deshazla ahora.
-- Reconstruye la imagen de Alpine con una compilación corregida de OpenSSL, lo que soluciona un fallo de arranque en instalaciones que se conectan a una base de datos MySQL/MariaDB mediante TLS.
+- Necesario para los clientes de Bitwarden en la versión 2026.8.0 o posterior. Actualiza antes de informar de problemas con un cliente reciente.
+- Actualiza la bóveda web a la versión 2026.7.0.
+- Corrige la actualización de las colecciones a las que pertenece un elemento y el registro de eventos de un usuario concreto.
+- Registra la dirección de correo del usuario en las entradas de registro de inicios de sesión correctos.
 
-Notas de la versión upstream: https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.1`,
-    de_DE: `Vaultwarden auf 1.37.1 aktualisiert.
+Notas de la versión upstream: https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.2`,
+    de_DE: `Vaultwarden auf 1.37.2 aktualisiert.
 
-- Behebt Organisationseinladungen, die in 1.37.0 defekt waren. Falls du lokal einen Workaround dafür eingesetzt hast, mache ihn jetzt rückgängig.
-- Erstellt das Alpine-Image mit einem korrigierten OpenSSL-Build neu und behebt damit einen Startabsturz bei Installationen, die sich per TLS mit einer MySQL-/MariaDB-Datenbank verbinden.
+- Erforderlich für Bitwarden-Clients ab Version 2026.8.0. Aktualisiere, bevor du Probleme mit einem aktuellen Client meldest.
+- Aktualisiert den Web-Tresor auf 2026.7.0.
+- Behebt das Aktualisieren der Sammlungen, zu denen ein Eintrag gehört, sowie das Ereignisprotokoll für einen einzelnen Benutzer.
+- Erfasst die E-Mail-Adresse des Benutzers in den Protokolleinträgen erfolgreicher Anmeldungen.
 
-Upstream-Release-Notes: https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.1`,
-    pl_PL: `Zaktualizowano Vaultwarden do 1.37.1.
+Upstream-Release-Notes: https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.2`,
+    pl_PL: `Zaktualizowano Vaultwarden do 1.37.2.
 
-- Naprawia zaproszenia do organizacji, które nie działały w wersji 1.37.0. Jeśli zastosowano lokalnie obejście tego problemu, należy je teraz cofnąć.
-- Przebudowuje obraz Alpine z poprawioną kompilacją OpenSSL, co usuwa awarię uruchamiania w instalacjach łączących się z bazą danych MySQL/MariaDB przez TLS.
+- Wymagane dla klientów Bitwarden w wersji 2026.8.0 lub nowszej. Zaktualizuj przed zgłoszeniem problemów z nowym klientem.
+- Aktualizuje sejf internetowy do wersji 2026.7.0.
+- Naprawia aktualizowanie kolekcji, do których należy wpis, oraz dziennik zdarzeń pojedynczego użytkownika.
+- Zapisuje adres e-mail użytkownika we wpisach dziennika udanych logowań.
 
-Informacje o wydaniu upstream: https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.1`,
-    fr_FR: `Vaultwarden mis à jour vers 1.37.1.
+Informacje o wydaniu upstream: https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.2`,
+    fr_FR: `Vaultwarden mis à jour vers 1.37.2.
 
-- Corrige les invitations d'organisation, qui étaient cassées en 1.37.0. Si vous avez appliqué un contournement localement, annulez-le maintenant.
-- Reconstruit l'image Alpine avec une compilation OpenSSL corrigée, ce qui résout un plantage au démarrage sur les installations qui se connectent à une base de données MySQL/MariaDB via TLS.
+- Nécessaire pour les clients Bitwarden en version 2026.8.0 ou ultérieure. Mettez à jour avant de signaler des problèmes avec un client récent.
+- Met à jour le coffre web vers 2026.7.0.
+- Corrige la mise à jour des collections auxquelles appartient un élément, ainsi que le journal d'événements d'un utilisateur donné.
+- Enregistre l'adresse e-mail de l'utilisateur dans les entrées de journal des connexions réussies.
 
-Notes de version en amont : https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.1`,
+Notes de version en amont : https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.2`,
   },
   migrations: {},
 })


### PR DESCRIPTION
Bumps Vaultwarden from 1.37.1 to 1.37.2 and resets the StartOS revision, `1.37.1:0` → `1.37.2:0`.

## Upstream bump

`startos/manifest/index.ts` pins `vaultwarden/server:1.37.2-alpine`. The tag is published on Docker Hub for both architectures the manifest declares (`amd64`, `arm64`), last pushed 2026-08-22.

Upstream calls this update **required for Bitwarden clients on version 2026.8.0 or newer** ([#7607](https://github.com/dani-garcia/vaultwarden/issues/7607), fixed by [#7608](https://github.com/dani-garcia/vaultwarden/pull/7608)). The rest of the release updates the web vault to 2026.7.0, fixes updating the collections an item belongs to and the per-user event log, and adds the user's email address to successful login log entries. [Full upstream notes.](https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.2)

## What did not change

- **start-sdk** is already pinned at `2.0.9`, the latest on npm — nothing to bump, and `package-lock.json` is untouched.
- **`*-startos` git dependencies** — the package has none, direct or transitive.
- **Version file structure** — the version leaving `current.ts` (`1.37.1:0`) carries no migration, so `current.ts` was edited in place. `index.ts` and its `other: [v_1_36_0_3]` entry are untouched; that is the version that holds the migration.
- **No package changes.** Nothing in 1.37.2 touches the config keys this package owns, the SMTP path, or the admin-token flow, so the upstream bump made no package enhancement obvious.

## Verification

- `1.37.2-alpine` resolves on Docker Hub, multi-arch, before pinning.
- The registry's latest published `vaultwarden` version is `1.37.1:0`, so `1.37.2:0` is free — this branch is not claiming a revision `master` has already released.
- `npm run check` green; `prettier --check` clean on both changed files.
- Not run, per the monitor cycle: `make`, s9pk pack, install/runtime test.

Release notes are written in all five locales the package ships.

**Merge with a merge commit — do not squash.** `next` is long-lived: a merge commit leaves it a true ancestor of `master`, so it fast-forwards cleanly afterwards. A squash re-lands the same content under a new commit, so the branch is left carrying history `master` will never contain.
